### PR TITLE
dirlist: Exclude noisy subdirectories of competitions

### DIFF
--- a/ifmap.py
+++ b/ifmap.py
@@ -1070,6 +1070,8 @@ def generate_output_dirlist(dirmap):
         dirlist.sort(key=lambda dir:dir.dir.lower())
         itermap = {}
         for dir in dirlist:
+            if re.search(r'^if-archive/games/competition\d+/', dir.dir) or re.search(r'^if-archive/games/springthing/\d+/', dir.dir):
+                continue
             parity_flip(itermap)
             Template.substitute(dirlist_entry, ChainMap(itermap, dir.submap), outfl=outfl)
             outfl.write('\n')


### PR DESCRIPTION
https://ifarchive.org/indexes/dirlist.html

There are 3,696 directories in `dirlist.html`, but 3,010 of those are subdirectories of `if-archive/games/competition*` or `if-archive/games/springthing/*`.

This PR excludes those subdirectories, reducing the length of `dirlist.html` to a much more manageable 686 entries.