### PR TITLE
Download Master-Index.xml

### DIFF
--- a/lib/toplevel.html
+++ b/lib/toplevel.html
@@ -17,7 +17,7 @@ You may be interested in...
 <ul id="toplinklist">
 <li>The <a href="{relroot}/if-archive/README">README file for the Archive</a>
 <li>An <a href="{relroot}/if-archive/directory-tree">ASCII directory tree map</a>
-<li><a href="{relroot}/indexes/Master-Index.xml">Master-Index.xml</a>,
+<li><a download href="{relroot}/indexes/Master-Index.xml">Master-Index.xml</a>,
 which describes every file in the Archive (very large XML file!)
 </ul>
 

--- a/testdata/indexes/if-archive.html
+++ b/testdata/indexes/if-archive.html
@@ -40,7 +40,7 @@ You may be interested in...
 <ul id="toplinklist">
 <li>The <a href="../if-archive/README">README file for the Archive</a>
 <li>An <a href="../if-archive/directory-tree">ASCII directory tree map</a>
-<li><a href="../indexes/Master-Index.xml">Master-Index.xml</a>,
+<li><a download href="../indexes/Master-Index.xml">Master-Index.xml</a>,
 which describes every file in the Archive (very large XML file!)
 </ul>
 

--- a/testdata/indexes/if-archive/index.html
+++ b/testdata/indexes/if-archive/index.html
@@ -40,7 +40,7 @@ You may be interested in...
 <ul id="toplinklist">
 <li>The <a href="../../if-archive/README">README file for the Archive</a>
 <li>An <a href="../../if-archive/directory-tree">ASCII directory tree map</a>
-<li><a href="../../indexes/Master-Index.xml">Master-Index.xml</a>,
+<li><a download href="../../indexes/Master-Index.xml">Master-Index.xml</a>,
 which describes every file in the Archive (very large XML file!)
 </ul>
 


### PR DESCRIPTION
When you click on the link to Master-Index.xml in Google Chrome, it just renders the file using Chrome's default stylesheet, which hides all tag names. It's illegible.

This PR adds the [download](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) attribute to the link, so, when you click on it, it starts downloading instead of trying to render it in the browser.

<img width="802" alt="image" src="https://github.com/iftechfoundation/ifarchive-ifmap-py/assets/96150/c4356024-2033-48ac-813e-7e590c0f1f98">
