### PR TITLE
Merge deep files

### DIFF
--- a/testdata/indexes/Master-Index.xml
+++ b/testdata/indexes/Master-Index.xml
@@ -347,6 +347,10 @@ Game number 1.
 <parent>if-archive/games/old</parent>
 <filecount>1</filecount>
 <subdircount>0</subdircount>
+<description>
+
+A double-depth directory.
+</description>
 </directory>
 
 
@@ -359,6 +363,10 @@ Game number 1.
 <rawdate>1538800000</rawdate>
 <md5>9ddfc5003ba50de6ab967c67a92a78f9</md5>
 <sha512>427f788dfb72c2878413c627d03bbd43de8e0bf0cff46347ebec7c0865c5abf1d7121d0c7e335bf41f1217abd4c07893d6219d6abecec29d91c6b2c901c9fdf7</sha512>
+<description>
+
+Triple-depth file reference.
+</description>
 </file>
 
 

--- a/testdata/indexes/archive.rss
+++ b/testdata/indexes/archive.rss
@@ -174,6 +174,9 @@ Game number 1.
     <guid>if-archive/games/old/older/game1-pre::1538800000</guid>
     <pubDate>Sat, 06 Oct 2018 04:26:40 +0000</pubDate>
     <description>
+    
+Triple-depth file reference.
+
     [at: if-archive/games/old/older/game1-pre]
     </description>
     </item>

--- a/testdata/indexes/datev.html
+++ b/testdata/indexes/datev.html
@@ -160,6 +160,7 @@ Release 1 / Serial number 000000</p>
 
 <dt id="if-archive/games/old/older/game1-pre" class="ParOdd"><span class="Date">[06-Oct-2018]</span>
 <a href="/if-archive/games/old/older/game1-pre">if-archive/<wbr>games/<wbr>old/<wbr>older/<wbr>game1-pre</a>
+    <dd><p>Triple-depth file reference.</p>
 
 </dl>
 

--- a/testdata/indexes/datev_3.html
+++ b/testdata/indexes/datev_3.html
@@ -158,6 +158,7 @@ Release 1 / Serial number 000000</p>
 
 <dt id="if-archive/games/old/older/game1-pre" class="ParEven"><span class="Date">[06-Oct-2018]</span>
 <a href="/if-archive/games/old/older/game1-pre">if-archive/<wbr>games/<wbr>old/<wbr>older/<wbr>game1-pre</a>
+    <dd><p>Triple-depth file reference.</p>
 
 </dl>
 

--- a/testdata/indexes/datev_4.html
+++ b/testdata/indexes/datev_4.html
@@ -158,6 +158,7 @@ Release 1 / Serial number 000000</p>
 
 <dt id="if-archive/games/old/older/game1-pre" class="ParEven"><span class="Date">[06-Oct-2018]</span>
 <a href="/if-archive/games/old/older/game1-pre">if-archive/<wbr>games/<wbr>old/<wbr>older/<wbr>game1-pre</a>
+    <dd><p>Triple-depth file reference.</p>
 
 </dl>
 

--- a/testdata/indexes/if-archive/games/old/older/index.html
+++ b/testdata/indexes/if-archive/games/old/older/index.html
@@ -35,7 +35,7 @@
 
 <div class="Description">
 
-
+<p>A double-depth directory.</p>
 <hr>
 
 
@@ -50,6 +50,7 @@
 
 <a class="PermaLink" href="#game1-pre">&#x25C6;</a>
   <span class="Date">[06-Oct-2018]</span>
+  <dd><p>Triple-depth file reference.</p>
 
 
 </dl>


### PR DESCRIPTION
#41 suggested providing an alternate representation for deep-link descriptions, but as far as I can tell, whenever there's a deep-link file with description, the corresponding "shallow" file doesn't have a description, so in this implementation I just set the shallow-file description to the deep-link description, logging a warning if this assumption is incorrect.

As a result, I didn't (need to) change the rendering for `Master-Index.xml`. The shallow files now appear to have their own description and metadata, as if they'd always been that way.